### PR TITLE
Suppress caching on live server

### DIFF
--- a/example-client/example-realtime-helper.php
+++ b/example-client/example-realtime-helper.php
@@ -10,6 +10,11 @@
 /* this isn't actually valid JSON - each row is a JSON result! */
 header("Content-type: application/json;charset=UTF-8");
 header("Connection: close");
+
+// Necessary on the live server to suppress caching so that
+// the results update in a timely fashion.
+while (@ob_end_clean());
+
 ini_set("output_buffering", "off");
 ob_implicit_flush(1);
 ob_flush();


### PR DESCRIPTION
I tried to test this using the Vagrant VM but got confused by the behaviour there (see my post to the tech-vols list). Is it safe to add this line to the example-realtime-helper.php script or will it break the example client?

Paging @Polarisation ...
